### PR TITLE
Add `LibLog` library

### DIFF
--- a/src/helpers/HelperLog.sol
+++ b/src/helpers/HelperLog.sol
@@ -1,189 +1,66 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {LibLog} from "../libraries/LibLog.sol";
+
 abstract contract HelperLog {
-    event Log(string debugString);
-    event LogString(string description, string data);
-    event LogString(string prefix, string description, string data);
-    event LogBytes(string description, bytes data);
-    event LogBytes(string prefix, string description, bytes data);
-    event LogUint(string description, uint256 data);
-    event LogUint(string prefix, string description, uint256 data);
-    event LogInt(string description, int256 data);
-    event LogInt(string prefix, string description, int256 data);
-    event LogAddress(string description, address data);
-    event LogAddress(string prefix, string description, address data);
-    event LogBool(string description, bool data);
-    event LogBool(string prefix, string description, bool data);
-    
-    event AssertionFailed();
-    event AssertionFailed(string description);
-    event AssertionFailed(string description, string data);
-    event AssertionFailed(string prefix, string description, string data);
-    event AssertionFailed(string description, bytes data);
-    event AssertionFailed(string prefix, string description, bytes data);
-    event AssertionFailed(string description, uint256 data);
-    event AssertionFailed(string prefix, string description, uint256 data);
-    event AssertionFailed(string description, int256 data);
-    event AssertionFailed(string prefix, string description, int256 data);
-    event AssertionFailed(string description, address data);
-    event AssertionFailed(string prefix, string description, address data);
-    event AssertionFailed(string description, bool data);
-    event AssertionFailed(string prefix, string description, bool data);
-
-    function log(string memory debugString) public {
-        emit Log(debugString);
+    function log(string memory message) public {
+        LibLog.log(message);
     }
 
-    function log(string memory description, string memory data) public {
-        emit LogString(description, data);
+    function log(string memory message, string memory data) public {
+        LibLog.log(message, data);
     }
 
-    function log(
-        string memory prefix,
-        string memory description,
-        string memory data
-    ) public {
-        emit LogString(prefix, description, data);
+    function log(string memory message, bytes memory data) public {
+        LibLog.log(message, data);
     }
 
-    function log(string memory description, bytes memory data) public {
-        emit LogBytes(description, data);
+    function log(string memory message, uint256 data) public {
+        LibLog.log(message, data);
     }
 
-    function log(
-        string memory prefix,
-        string memory description,
-        bytes memory data
-    ) public {
-        emit LogBytes(prefix, description, data);
+    function log(string memory message, int256 data) public {
+        LibLog.log(message, data);
     }
 
-    function log(string memory description, uint256 data) public {
-        emit LogUint(description, data);
+    function log(string memory message, address data) public {
+        LibLog.log(message, data);
     }
 
-    function log(
-        string memory prefix,
-        string memory description,
-        uint256 data
-    ) public {
-        emit LogUint(prefix, description, data);
-    }
-
-    function log(string memory description, int256 data) public {
-        emit LogInt(description, data);
-    }
-
-    function log(
-        string memory prefix,
-        string memory description,
-        int256 data
-    ) public {
-        emit LogInt(prefix, description, data);
-    }
-
-    function log(string memory description, address data) public {
-        emit LogAddress(description, data);
-    }
-
-    function log(
-        string memory prefix,
-        string memory description,
-        address data
-    ) public {
-        emit LogAddress(prefix, description, data);
-    }
-
-    function log(string memory description, bool data) public {
-        emit LogBool(description, data);
-    }
-
-    function log(
-        string memory prefix,
-        string memory description,
-        bool data
-    ) public {
-        emit LogBool(prefix, description, data);
+    function log(string memory message, bool data) public {
+        LibLog.log(message, data);
     }
 
     function logFail() public {
-        emit AssertionFailed();
+        LibLog.logFail();
     }
 
-    function logFail(string memory debugString) public {
-        emit AssertionFailed(debugString);
+    function logFail(string memory message) public {
+        LibLog.logFail(message);
     }
 
-    function logFail(string memory description, string memory data) public {
-        emit AssertionFailed(description, data);
+    function logFail(string memory message, string memory data) public {
+        LibLog.logFail(message, data);
     }
 
-    function logFail(
-        string memory prefix,
-        string memory description,
-        string memory data
-    ) public {
-        emit AssertionFailed(prefix, description, data);
+    function logFail(string memory message, bytes memory data) public {
+        LibLog.logFail(message, data);
     }
 
-    function logFail(string memory description, bytes memory data) public {
-        emit AssertionFailed(description, data);
+    function logFail(string memory message, uint256 data) public {
+        LibLog.logFail(message, data);
     }
 
-    function logFail(
-        string memory prefix,
-        string memory description,
-        bytes memory data
-    ) public {
-        emit AssertionFailed(prefix, description, data);
+    function logFail(string memory message, int256 data) public {
+        LibLog.logFail(message, data);
     }
 
-    function logFail(string memory description, uint256 data) public {
-        emit AssertionFailed(description, data);
+    function logFail(string memory message, address data) public {
+        LibLog.logFail(message, data);
     }
 
-    function logFail(
-        string memory prefix,
-        string memory description,
-        uint256 data
-    ) public {
-        emit AssertionFailed(prefix, description, data);
-    }
-
-    function logFail(string memory description, int256 data) public {
-        emit AssertionFailed(description, data);
-    }
-
-    function logFail(
-        string memory prefix,
-        string memory description,
-        int256 data
-    ) public {
-        emit AssertionFailed(prefix, description, data);
-    }
-
-    function logFail(string memory description, address data) public {
-        emit AssertionFailed(description, data);
-    }
-
-    function logFail(
-        string memory prefix,
-        string memory description,
-        address data
-    ) public {
-        emit AssertionFailed(prefix, description, data);
-    }
-
-    function logFail(string memory description, bool data) public {
-        emit AssertionFailed(description, data);
-    }
-
-    function logFail(
-        string memory prefix,
-        string memory description,
-        bool data
-    ) public {
-        emit AssertionFailed(prefix, description, data);
+    function logFail(string memory message, bool data) public {
+        LibLog.logFail(message, data);
     }
 }

--- a/src/libraries/LibLog.sol
+++ b/src/libraries/LibLog.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+library LibLog {
+    event Log(string message);
+    event LogString(string message, string data);
+    event LogBytes(string message, bytes data);
+    event LogUint(string message, uint256 data);
+    event LogInt(string message, int256 data);
+    event LogAddress(string message, address data);
+    event LogBool(string message, bool data);
+    
+    event AssertionFailed();
+    event AssertionFailed(string message);
+    event AssertionFailed(string message, string data);
+    event AssertionFailed(string message, bytes data);
+    event AssertionFailed(string message, uint256 data);
+    event AssertionFailed(string message, int256 data);
+    event AssertionFailed(string message, address data);
+    event AssertionFailed(string message, bool data);
+
+    function log(string memory message) internal {
+        emit Log(message);
+    }
+
+    function log(string memory message, string memory data) internal {
+        emit LogString(message, data);
+    }
+
+    function log(string memory message, bytes memory data) internal {
+        emit LogBytes(message, data);
+    }
+
+    function log(string memory message, uint256 data) internal {
+        emit LogUint(message, data);
+    }
+
+    function log(string memory message, int256 data) internal {
+        emit LogInt(message, data);
+    }
+
+    function log(string memory message, address data) internal {
+        emit LogAddress(message, data);
+    }
+
+    function log(string memory message, bool data) internal {
+        emit LogBool(message, data);
+    }
+
+    function logFail() internal {
+        emit AssertionFailed();
+    }
+
+    function logFail(string memory message) internal {
+        emit AssertionFailed(message);
+    }
+
+    function logFail(string memory message, string memory data) internal {
+        emit AssertionFailed(message, data);
+    }
+
+    function logFail(string memory message, bytes memory data) internal {
+        emit AssertionFailed(message, data);
+    }
+
+    function logFail(string memory message, uint256 data) internal {
+        emit AssertionFailed(message, data);
+    }
+
+    function logFail(string memory message, int256 data) internal {
+        emit AssertionFailed(message, data);
+    }
+
+    function logFail(string memory message, address data) internal {
+        emit AssertionFailed(message, data);
+    }
+
+    function logFail(string memory message, bool data) internal {
+        emit AssertionFailed(message, data);
+    }
+}


### PR DESCRIPTION
This adds the ability to easily use fuzzlib logging from other libraries