### PR TITLE
feat: add allowErrors fn which handle require & custom error failure …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@perimetersec/fuzzlib",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Solidity Fuzzing Library",
   "homepage": "https://github.com/perimetersec/fuzzlib#readme",
   "author": "Perimeter <info@perimetersec.io>",

--- a/src/helpers/HelperAssert.sol
+++ b/src/helpers/HelperAssert.sol
@@ -390,13 +390,11 @@ abstract contract HelperAssert is HelperBase {
         bytes4 selector = bytes4(errorData);
         
         if (_isErrorString(selector)) {
-            // 2. require failure case (ex: require(false, "error message"))
+            // 1. require failure case (ex: require(false, "error message"))
             _allowRequireFailure(errorData, allowedRequireErrorMessages);
-        } else if (allowedCustomErrors.length > 0) {
-            // 3. custom error case (ex: MyCustomError())
-            errAllow(selector, allowedCustomErrors, errorContext);
         } else {
-            t(false, "unexpected error type during allowErrors()");
+            // 2. custom error case (ex: MyCustomError())
+            errAllow(selector, allowedCustomErrors, errorContext);
         }
     }
     

--- a/src/helpers/HelperAssert.sol
+++ b/src/helpers/HelperAssert.sol
@@ -318,6 +318,7 @@ abstract contract HelperAssert is HelperBase {
         t(isEqual, assertMsg);
     }
 
+    // allow custom error only
     function errAllow(
         bytes4 errorSelector,
         bytes4[] memory allowedErrors,
@@ -353,20 +354,13 @@ abstract contract HelperAssert is HelperBase {
     function createAssertFailMessage(string memory aStr, string memory bStr, string memory operator, string memory reason)internal pure returns (string memory) {
         return string(abi.encodePacked("Invalid: ", aStr, operator, bStr, ", reason: ", reason));
     }
-
-    function allowErrors(  
+    // require failure only
+    function errAllow(  
         bytes memory errorData,
-        string[] memory allowedRequireErrorMessages
-    ) public {
-        allowErrors(errorData, allowedRequireErrorMessages, new bytes4[](0), "");
-    }
-    
-    function allowErrors(  
-        bytes memory errorData,
-        bytes4[] memory allowedCustomErrors,
+        string[] memory allowedRequireErrorMessages,
         string memory errorContext
     ) public {
-        allowErrors(errorData, new string[](0), allowedCustomErrors, errorContext);
+        errAllow(errorData, allowedRequireErrorMessages, new bytes4[](0), errorContext);
     }
     
     /**
@@ -376,7 +370,7 @@ abstract contract HelperAssert is HelperBase {
      * @param allowedCustomErrors: allowed custom errors. It can be just an array of 4 bytes function selector or it could be longer
      * @param errorContext: error context: A message to describe the error
      */
-    function allowErrors(  
+    function errAllow(  
         bytes memory errorData,
         string[] memory allowedRequireErrorMessages,
         bytes4[] memory allowedCustomErrors,
@@ -387,7 +381,7 @@ abstract contract HelperAssert is HelperBase {
         
         if (_isErrorString(selector)) {
             // 1. require failure case (ex: require(false, "error message"))
-            _allowRequireFailure(errorData, allowedRequireErrorMessages);
+            _allowRequireFailure(errorData, allowedRequireErrorMessages, errorContext);
         } else {
             // 2. custom error case (ex: MyCustomError())
             errAllow(selector, allowedCustomErrors, errorContext);
@@ -403,7 +397,8 @@ abstract contract HelperAssert is HelperBase {
     // check whether the errorData is an expected failure by checking the error message
     function _allowRequireFailure(
         bytes memory errorData,
-        string[] memory allowedRequireErrorMessages
+        string[] memory allowedRequireErrorMessages,
+        string memory errorContext
     ) internal {
         // space for error message without selector (4 bytes)
         bytes memory strippedData = new bytes(errorData.length - 4);
@@ -435,7 +430,6 @@ abstract contract HelperAssert is HelperBase {
             }
         }
 
-        t(allowed, decodedString);
+        t(allowed, errorContext);
     }
-    
 }

--- a/src/helpers/HelperAssert.sol
+++ b/src/helpers/HelperAssert.sol
@@ -358,7 +358,7 @@ abstract contract HelperAssert is HelperBase {
         bytes memory errorData,
         string[] memory allowedRequireErrorMessages
     ) public {
-        allowErrors(errorData, allowedRequireErrorMessages, new bytes4[](0), "", false);
+        allowErrors(errorData, allowedRequireErrorMessages, new bytes4[](0), "");
     }
     
     function allowErrors(  
@@ -366,42 +366,22 @@ abstract contract HelperAssert is HelperBase {
         bytes4[] memory allowedCustomErrors,
         string memory errorContext
     ) public {
-        allowErrors(errorData, new string[](0), allowedCustomErrors, errorContext, false);
-    }
-    
-    function allowErrors(  
-        bytes memory errorData,
-        string[] memory allowedRequireErrorMessages,
-        bytes4[] memory allowedCustomErrors,
-        string memory errorContext
-    ) public {
-        allowErrors(errorData, allowedRequireErrorMessages, allowedCustomErrors, errorContext, false);
+        allowErrors(errorData, new string[](0), allowedCustomErrors, errorContext);
     }
     
     /**
      * Allow require failure & custom errors
      * @param errorData: return data from a function call. In this case, it's a failure data
      * @param allowedRequireErrorMessages: allowed require failure messages. It's a string array
-     * @param allowedCustomErrors: allowed custom errors. It can be just 4 bytes function selector or it could be longer
+     * @param allowedCustomErrors: allowed custom errors. It can be just an array of 4 bytes function selector or it could be longer
      * @param errorContext: error context: A message to describe the error
-     * @param allowEmptyError: allow require failure without message
      */
     function allowErrors(  
         bytes memory errorData,
         string[] memory allowedRequireErrorMessages,
         bytes4[] memory allowedCustomErrors,
-        string memory errorContext,
-        bool allowEmptyError
+        string memory errorContext
     ) public {
-        if (allowEmptyError && errorData.length == 0) {
-            // 1. empty error case (ex: require(false)) <= useful when there is no error message, errorData is empty
-            // NOTE: Becareful! It could be "require" or "revert" failure without message BUT also it could be something else such as 
-            // calling non-existing address (ex: address(0xdead).call(...)). The root-cause could be various. Please check the 
-            // code and the context before use allowEmptyError = true.
-            _handleEmptyError(allowEmptyError);
-            return;
-        }
-    
         if (errorData.length < 4) {
             t(false, "unexpected error data length during allowErrors()");
             return;
@@ -424,10 +404,6 @@ abstract contract HelperAssert is HelperBase {
     function _isErrorString(bytes4 selector) internal pure returns (bool) {
         // 0x08c379a0 is the selector for "Error(string)" which is the error type for require(...) failure
         return selector == 0x08c379a0;
-    }
-    
-    function _handleEmptyError(bool allowEmptyError) internal {
-        t(allowEmptyError, "Becareful! It could be require or revert failure without message but also it could be something else such as calling non-existing address address(0xdead). The root-cause could be various. Please check the code and the context.");
     }
     
     // check whether the errorData is an expected failure by checking the error message

--- a/src/helpers/HelperAssert.sol
+++ b/src/helpers/HelperAssert.sol
@@ -383,7 +383,7 @@ abstract contract HelperAssert is HelperBase {
         string memory errorContext
     ) public {
         if (errorData.length < 4) {
-            t(false, "unexpected error data length during allowErrors()");
+            t(false, "The length of errorData must be at least 4 or more");
             return;
         }
     

--- a/test/Assert.t.sol
+++ b/test/Assert.t.sol
@@ -9,8 +9,9 @@ import "src/FuzzLibString.sol";
 import {HelperAssert} from "../src/helpers/HelperAssert.sol";
 import {PlatformTest} from "./util/PlatformTest.sol";
 import {DummyContract} from "./util/DummyContract.sol";
+import {ErrAllowTestHelper} from "./util/ErrAllowTestHelper.sol";
 
-contract TestAsserts is Test, HelperAssert {
+contract TestAsserts is Test, HelperAssert, ErrAllowTestHelper {
     DummyContract dummy;
 
     function setUp() public {
@@ -200,131 +201,155 @@ contract TestAsserts is Test, HelperAssert {
      * "errAllow" test
      */
 
-    // errAllow() use case 1: allowing only require failure with message
-    function test_errAllow_only_require_failure_with_message() public {
+    // errAllow() use case 1-1: allowing only require failure with message
+    function test_errAllow_only_require_failure_happy_path() public {
         // set require failure related
-        string[] memory allowedRequireErrors = new string[](2);
-        allowedRequireErrors[0] = "require failure message 1";
-        allowedRequireErrors[1] = "require failure message 2";
-        
-        // #1: Test with require failure: Error(string) selector (0x08c379a0)
-        (bool success1, bytes memory requireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
-        require(!success1, "should fail");
-        // This should pass
-        errAllow(requireFailureData, allowedRequireErrors, "BAL-01");
-        
-        // #2: Test with non-matching message (should fail)
+        string[] memory allowedRequireErrors = setup_errAllow_require_error();
+
+        // Test with require failure: Error(string) selector (0x08c379a0)
+        (bool success, bytes memory requireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success, "should fail");
+        // This should pass since the error message is in the allowedRequireErrors list.
+        errAllow(requireFailureData, allowedRequireErrors, "ERR_ALLOW_01");
+    }
+
+    // errAllow() use case 1-2: allowing only require failure with message
+    function test_errAllow_only_require_failure_unhappy_path() public {
+        // set require failure related
+        string[] memory allowedRequireErrors = setup_errAllow_require_error();
+
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
         vm.expectEmit(false, false, false, true);
         // expected error message via event
-        emit AssertFail("BAL-02");
+        emit AssertFail("ERR_ALLOW_02");
         bytes memory nonMatchingRequireFailData = abi.encodeWithSelector(bytes4(0x08c379a0), "error message");
         // This should fail: since the failure message ("this should fail") is not in the allowedRequireErrors list.
-        errAllow(nonMatchingRequireFailData, allowedRequireErrors, "BAL-02");
+        errAllow(nonMatchingRequireFailData, allowedRequireErrors, "ERR_ALLOW_02");
     }
 
-    // errAllow() use case 2: allowing only custom error
-    function test_errAllow_only_custom_error() public {
-        // set custom error related
-        bytes4 customErrorSelector1 = bytes4(DummyContract.DummyCustomError1.selector);
-        bytes4 customErrorSelector2 = bytes4(DummyContract.DummyCustomError2.selector);
-        bytes4[] memory allowedCustomErrors = new bytes4[](2);
-        allowedCustomErrors[0] = customErrorSelector1;
-        allowedCustomErrors[1] = customErrorSelector2;
-        string memory errorContext = "BAL-03";
+    // errAllow() use case 2-1: allowing only custom error
+    function test_errAllow_only_custom_error_happy_path() public {
+       bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
 
-        // #1: Test with custom error selector
-        (bool success1, bytes memory customErrorData1) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
-        require(!success1, "should fail");
-        // This should pass
-        errAllow(bytes4(customErrorData1), allowedCustomErrors, errorContext);
+       // Test with custom error selector
+       (bool success, bytes memory customErrorData) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
+       require(!success, "This test supposes to fail");
+       // Nothing should happen since the error is in the allowedCustomErrors list.
+       errAllow(bytes4(customErrorData), allowedCustomErrors, "ERR_ALLOW_03");
+    }
 
-        // #2: Test with non-matching error (should fail)
+    // errAllow() use case 2-2: allowing only custom error
+    function test_errAllow_only_custom_error_unhappy_path_1() public {
+        bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
+
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(false, false, false, true);
         // expected error message via event
-        emit AssertFail(errorContext);
+        emit AssertFail("ERR_ALLOW_04");
         // This should fail: since the 0x08c379a0 is not in the allowedCustomErrors
+        // 0x08c379a0 is Error(string) which is not a custom error but a require failure.
         bytes memory randomErrorData = abi.encodeWithSelector(bytes4(0x08c379a0), "this should fail");   
-        errAllow(bytes4(randomErrorData), allowedCustomErrors, errorContext);
+        errAllow(bytes4(randomErrorData), allowedCustomErrors, "ERR_ALLOW_04");
+    }
 
-        // #3: Test with non-matching error (should fail)
+    // errAllow() use case 2-3: allowing only custom error
+    function test_errAllow_only_custom_error_unhappy_path_2() public {
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(false, false, false, true);
         // expected error message via event
-        emit AssertFail(errorContext);
+        emit AssertFail("ERR_ALLOW_05");
         bytes memory unexpectedErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
         // This should fail: allowedCustomErrors is empty array. But given unexpectedErrorData has a custom error. Therefore it will throw an error.
-        errAllow(bytes4(unexpectedErrorData), new bytes4[](0), errorContext);
+        errAllow(bytes4(unexpectedErrorData), new bytes4[](0), "ERR_ALLOW_05");
     }
 
-    // errAllow() use case 3: allowing require failure AND custom error at the same time
-    function test_errAllow_require_failure_and_custom_error() public {
+    // errAllow() use case 3-1: allowing require failure AND custom error at the same time
+    function test_errAllow_require_failure_and_custom_error_happy_path_1() public {
         // set require failure related
-        string[] memory allowedRequireErrors = new string[](2);
-        allowedRequireErrors[0] = "require failure message 1";
-        allowedRequireErrors[1] = "require failure message 2";
-
+        string[] memory allowedRequireErrors = setup_errAllow_require_error();
         // set custom error related
-        bytes4 customErrorSelector1 = bytes4(DummyContract.DummyCustomError1.selector);
-        bytes4 customErrorSelector2 = bytes4(DummyContract.DummyCustomError2.selector);
-        bytes4[] memory allowedCustomErrors = new bytes4[](2);
-        allowedCustomErrors[0] = customErrorSelector1;
-        allowedCustomErrors[1] = customErrorSelector2;
-        string memory errorContext = "BAL-03";
+        bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
 
-        // #1: Test with require failure with message
-        (bool success1, bytes memory requireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
-        require(!success1, "should fail");
+        (bool success, bytes memory requireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success, "This test supposes to fail");
         // This should pass: testing require failure
-        errAllow(requireFailureData, allowedRequireErrors, allowedCustomErrors, errorContext);
+        errAllow(requireFailureData, allowedRequireErrors, allowedCustomErrors, "ERR_ALLOW_06");
+    }
 
-        // #2: Test with custom error without message
-        (bool success2, bytes memory customErrorData1) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithoutMessage()"));
-        require(!success2, "should fail");
+    // errAllow() use case 3-2: allowing require failure AND custom error at the same time
+    function test_errAllow_require_failure_and_custom_error_happy_path_2() public {
+        // set require failure related
+        string[] memory allowedRequireErrors = setup_errAllow_require_error();
+        // set custom error related
+        bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
+
+        (bool success, bytes memory customErrorData) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithoutMessage()"));
+        require(!success, "This test supposes to fail");
         // This should pass: testing custom error without message
-        errAllow(customErrorData1, allowedRequireErrors, allowedCustomErrors, errorContext);
+        errAllow(customErrorData, allowedRequireErrors, allowedCustomErrors, "ERR_ALLOW_07");
+    }
 
-        // #3: Test with custom error with message
-        (bool success3, bytes memory customErrorData2) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
-        require(!success3, "should fail");
+    // errAllow() use case 3-3: allowing require failure AND custom error at the same time
+    function test_errAllow_require_failure_and_custom_error_happy_path_3() public {
+        // set require failure related
+        string[] memory allowedRequireErrors = setup_errAllow_require_error();
+        // set custom error related
+        bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
+        
+        (bool success, bytes memory customErrorData) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
+        require(!success, "This test supposes to fail");
         // This should pass: testing custom error with message
-        errAllow(customErrorData2, allowedRequireErrors, allowedCustomErrors, errorContext);
+        errAllow(customErrorData, allowedRequireErrors, allowedCustomErrors, "ERR_ALLOW_08");
+    }
 
-        // #4: Test with non-matching error (should fail)
+    // errAllow() use case 3-4: allowing require failure AND custom error at the same time
+    function test_errAllow_require_failure_and_custom_error_unhappy_path_1() public {
+        // set custom error related
+        bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
+
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(false, false, false, true);
         // expected error message via event
-        emit AssertFail(errorContext);
+        emit AssertFail("ERR_ALLOW_09");
 
         bytes memory nonMatchingRequireFailData = abi.encodeWithSelector(bytes4(0x08c379a0), "this should fail");
         // This should fail: since the selector is require failure e.g.: Error(string). So nothing to do with allowedCustomErrors & errorContext.
-        errAllow(nonMatchingRequireFailData, new string[](0), allowedCustomErrors, errorContext);
+        errAllow(nonMatchingRequireFailData, new string[](0), allowedCustomErrors, "ERR_ALLOW_09");
+    }
 
-        // #5: Test with non-matching error (should fail)
+    // errAllow() use case 3-5: allowing require failure AND custom error at the same time
+    function test_errAllow_require_failure_and_custom_error_unhappy_path_2() public {
+        // set require failure related
+        string[] memory allowedRequireErrors = setup_errAllow_require_error();
+
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(false, false, false, true);
         // expected error message via event
-        emit AssertFail(errorContext);
+        emit AssertFail("ERR_ALLOW_10");
         bytes memory unexpectedErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
         // This should fail: It will be treated as custom error but the third param is empty array. So it will throw an error.
-        errAllow(unexpectedErrorData, allowedRequireErrors, new bytes4[](0), errorContext);
+        errAllow(unexpectedErrorData, allowedRequireErrors, new bytes4[](0), "ERR_ALLOW_10");
+    }
 
-        // #6: Test with non-matching custom error (should fail): checking whether errorContext is emitted or not
+    // errAllow() use case 3-6: allowing require failure AND custom error at the same time
+    function test_errAllow_require_failure_and_custom_error_unhappy_path_3() public {
+        // set custom error related
+        bytes4[] memory allowedCustomErrors = setup_errAllow_custom_error();
+
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(false, false, false, true);
         // expected error message via event
-        emit AssertFail(errorContext);
+        emit AssertFail("ERR_ALLOW_11");
     
         bytes memory nonMatchingCustomErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
         // This should fail and emit AssertFail with errorContext. "some message" will be ignored.
-        errAllow(nonMatchingCustomErrorData, new string[](0), allowedCustomErrors, errorContext);
+        errAllow(nonMatchingCustomErrorData, new string[](0), allowedCustomErrors, "ERR_ALLOW_11");
     }
 
-    // errAllow() use case 4: with zero selector test
+    // errAllow() use case 4-1: with zero selector test
     // note: this test is for when "errorSelector" is an empty data (0x00000000). This can happen from require(false) or revert() or address(0xdead).call().
     // This is not an usual case but it proves that errAllow() can handle this case.
-    function test_errAllow_zero_selector() public {
+    function test_errAllow_zero_selector_happy_path() public {
         // #1: Test with zero selector
         // emptyRequireFailureData will be an empty data since require(false); returns an empty data
         (bool success, bytes memory emptyRequireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithoutMessage()"));
@@ -332,26 +357,29 @@ contract TestAsserts is Test, HelperAssert {
 
         bytes4[] memory allowedErrors = new bytes4[](1);
         allowedErrors[0] = bytes4(0);
-        string memory message = "zero selector test";
         
         // emptyRequireFailureData is 0x00000000
         // This should pass since errorSelector (bytes4(0)) is in allowedErrors
-        errAllow(bytes4(emptyRequireFailureData), allowedErrors, message);
+        errAllow(bytes4(emptyRequireFailureData), allowedErrors, "ERR_ALLOW_12");
+    }
 
-        // #2: Test with different selector
-        (bool success2, bytes memory emptyRequireFailureData2) = address(dummy).call(abi.encodeWithSignature("requireFailWithoutMessage()"));
-        require(!success2, "should fail");
+    // errAllow() use case 4-2: with zero selector test
+    // note: this test is for when "errorSelector" is an empty data (0x00000000). This can happen from require(false) or revert() or address(0xdead).call().
+    // This is not an usual case but it proves that errAllow() can handle this case.
+    function test_errAllow_zero_selector_unhappy_path() public {
+        (bool success, bytes memory emptyRequireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithoutMessage()"));
+        require(!success, "should fail");
 
-        bytes4[] memory allowedErrors2 = new bytes4[](1);
-        allowedErrors2[0] = bytes4(0x12345678); // Different selector
-        string memory message2 = "zero selector test should fail";
+        bytes4[] memory allowedErrors = new bytes4[](1);
+        allowedErrors[0] = bytes4(0x12345678); // Different selector
         
         // This should fail since errorSelector (bytes4(0)) is not in allowedErrors
-        vm.expectEmit(true, false, false, true);
-        emit AssertFail(message2);
+        vm.expectEmit(false, false, false, true);
+        emit AssertFail("ERR_ALLOW_13");
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
         
-        errAllow(bytes4(emptyRequireFailureData2), allowedErrors2, message2);
+        // This should fail since errorSelector (bytes4(0)) is not in allowedErrors. 
+        errAllow(bytes4(emptyRequireFailureData), allowedErrors, "ERR_ALLOW_13");
     }
 
     function test_isErrorString() public {

--- a/test/Assert.t.sol
+++ b/test/Assert.t.sol
@@ -197,11 +197,11 @@ contract TestAsserts is Test, HelperAssert {
         }
 
     /**
-     * "allowErrors" test
+     * "errAllow" test
      */
 
     // errAllow() use case 1: allowing only require failure with message
-    function test_allowErrors_only_require_failure_with_message() public {
+    function test_errAllow_only_require_failure_with_message() public {
         // set require failure related
         string[] memory allowedRequireErrors = new string[](2);
         allowedRequireErrors[0] = "require failure message 1";
@@ -215,7 +215,7 @@ contract TestAsserts is Test, HelperAssert {
         
         // #2: Test with non-matching message (should fail)
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        vm.expectEmit(true, false, false, true);
+        vm.expectEmit(false, false, false, true);
         // expected error message via event
         emit AssertFail("BAL-02");
         bytes memory nonMatchingRequireFailData = abi.encodeWithSelector(bytes4(0x08c379a0), "error message");
@@ -224,7 +224,7 @@ contract TestAsserts is Test, HelperAssert {
     }
 
     // errAllow() use case 2: allowing only custom error
-    function test_allowErrors_only_custom_error() public {
+    function test_errAllow_only_custom_error() public {
         // set custom error related
         bytes4 customErrorSelector1 = bytes4(DummyContract.DummyCustomError1.selector);
         bytes4 customErrorSelector2 = bytes4(DummyContract.DummyCustomError2.selector);
@@ -248,7 +248,7 @@ contract TestAsserts is Test, HelperAssert {
         bytes memory randomErrorData = abi.encodeWithSelector(bytes4(0x08c379a0), "this should fail");   
         errAllow(bytes4(randomErrorData), allowedCustomErrors, errorContext);
 
-        // #5: Test with non-matching error (should fail)
+        // #3: Test with non-matching error (should fail)
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
         vm.expectEmit(true, false, false, true);
         // expected error message via event
@@ -259,7 +259,7 @@ contract TestAsserts is Test, HelperAssert {
     }
 
     // errAllow() use case 3: allowing require failure AND custom error at the same time
-    function test_allowErrors_require_failure_and_custom_error() public {
+    function test_errAllow_require_failure_and_custom_error() public {
         // set require failure related
         string[] memory allowedRequireErrors = new string[](2);
         allowedRequireErrors[0] = "require failure message 1";
@@ -369,23 +369,5 @@ contract TestAsserts is Test, HelperAssert {
         (bool success3, bytes memory emptyErrorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithoutMessage()"));
         require(!success3, "should fail");
         assertFalse(_isErrorString(bytes4(emptyErrorData)), "empty error should not be Error(string) type");
-    }
-
-    function test_errAllow_require_only_failure() public {
-        // Test with matching require failure message
-        (bool success, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
-        require(!success, "should fail");
-        
-        string[] memory allowedRequireErrors = new string[](1);
-        allowedRequireErrors[0] = "require failure message 1";
-        
-        // Test with matching message
-        errAllow(errorData, allowedRequireErrors, "BAL-01"); // should not revert
-        
-        // Test with non-matching message
-        vm.expectRevert(PlatformTest.TestAssertFail.selector);
-        string[] memory nonMatchingErrors = new string[](1);
-        nonMatchingErrors[0] = "different message";
-        errAllow(errorData, nonMatchingErrors, "BAL-02"); // should revert
     }
 }

--- a/test/Assert.t.sol
+++ b/test/Assert.t.sol
@@ -262,6 +262,15 @@ contract TestAsserts is Test, HelperAssert {
         // this should fail: since the custom error is not in the allowedCustomErrors, it should emit AssertFail with customErrorContext. "some message" will be ignored.
         bytes memory nonMatchingCustomErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
         allowErrors(nonMatchingCustomErrorData, allowedCustomErrors, customErrorContext);
+
+        // #5: Test with non-matching error (should fail)
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        vm.expectEmit(true, false, false, true);
+        // expected error message via event
+        emit AssertFail(customErrorContext);
+        bytes memory unexpectedErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
+        // This should fail: allowedCustomErrors is empty array. But given unexpectedErrorData has a custom error. Therefore it will throw an error.
+        allowErrors(unexpectedErrorData, new bytes4[](0), customErrorContext);
     }
 
     // allowErrors() use case 3: allowing require failure AND custom error at the same time
@@ -309,6 +318,9 @@ contract TestAsserts is Test, HelperAssert {
 
         // #5: Test with non-matching error (should fail)
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        vm.expectEmit(true, false, false, true);
+        // expected error message via event
+        emit AssertFail(customErrorContext);
         bytes memory unexpectedErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
         // This should fail: It will be treated as custom error but the third param is empty array. So it will throw an error.
         allowErrors(unexpectedErrorData, allowedRequireErrors, new bytes4[](0), customErrorContext);
@@ -320,7 +332,7 @@ contract TestAsserts is Test, HelperAssert {
         emit AssertFail(customErrorContext);
     
         bytes memory nonMatchingCustomErrorData = abi.encodeWithSelector(bytes4(0x12345678), "some message");
-        // This should fail and emit AssertFail with customErrorContext before reverting
+        // This should fail and emit AssertFail with customErrorContext. "some message" will be ignored.
         allowErrors(nonMatchingCustomErrorData, new string[](0), allowedCustomErrors, customErrorContext);
     }
 

--- a/test/Assert.t.sol
+++ b/test/Assert.t.sol
@@ -8,11 +8,14 @@ import "src/FuzzLibString.sol";
 
 import {HelperAssert} from "../src/helpers/HelperAssert.sol";
 import {PlatformTest} from "./util/PlatformTest.sol";
+import {DummyContract} from "./util/DummyContract.sol";
 
 contract TestAsserts is Test, HelperAssert {
+    DummyContract dummy;
 
     function setUp() public {
         setPlatform(address(new PlatformTest()));
+        dummy = new DummyContract();
     }
 
     /**
@@ -191,5 +194,190 @@ contract TestAsserts is Test, HelperAssert {
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
 
         neq(x, y, reason);
+        }
+
+    // allowErrors() use case 1: allowing only require failure with message
+    function test_allowErrors_only_require_failure_with_message() public {
+        string[] memory allowedRequireErrors = new string[](2);
+        allowedRequireErrors[0] = "require failure message 1";
+        allowedRequireErrors[1] = "require failure message 2";
+        
+        // Test with Error(string) selector (0x08c379a0)
+        bytes memory matchingErrorData = abi.encodeWithSelector(0x08c379a0, "require failure message 1");
+        bytes memory nonMatchingErrorData = abi.encodeWithSelector(0x08c379a0, "non-matching message");
+        
+        // This should pass
+        allowErrors(matchingErrorData, allowedRequireErrors);
+        
+        // Test with non-matching message (should fail)
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        // This should fail
+        allowErrors(nonMatchingErrorData, allowedRequireErrors);
+    }
+
+    // allowErrors() use case 2: allowing only custom error
+    function test_allowErrors_only_custom_error() public {
+        bytes4 customErrorSelector1 = bytes4(DummyContract.DummyCustomError1.selector);
+        bytes4 customErrorSelector2 = bytes4(DummyContract.DummyCustomError2.selector);
+        
+        bytes4[] memory allowedCustomErrors = new bytes4[](2);
+        allowedCustomErrors[0] = customErrorSelector1;
+        allowedCustomErrors[1] = customErrorSelector2;
+
+        // Test with custom error selector (with message)
+        (bool success1, bytes memory customErrorData1) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
+        require(!success1, "should fail");
+        // This should pass
+        allowErrors(customErrorData1, allowedCustomErrors, "custom error test failed. here is the context");
+
+        // Test with custom error selector (without message)
+        (bool success2, bytes memory customErrorData2) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithoutMessage()"));
+        require(!success2, "should fail");
+        // This should pass
+        allowErrors(customErrorData2, allowedCustomErrors, "custom error test failed. here is the context");
+
+        // Test with non-matching error (should fail)
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        // This should fail
+        bytes memory randomErrorData = abi.encodeWithSelector(bytes4(0x08c379a0), "require failure message");   
+        allowErrors(randomErrorData, allowedCustomErrors, "custom error test failed. here is the context");
+    }
+
+    // allowErrors() use case 3: allowing require failure AND custom error at the same time
+    function test_allowErrors_require_failure_and_custom_error() public {
+        // set require failure related
+        string[] memory allowedRequireErrors = new string[](2);
+        allowedRequireErrors[0] = "require failure message 1";
+        allowedRequireErrors[1] = "require failure message 2";
+
+        // set custom error related
+        bytes4 customErrorSelector1 = bytes4(DummyContract.DummyCustomError1.selector);
+        bytes4 customErrorSelector2 = bytes4(DummyContract.DummyCustomError2.selector);
+        bytes4[] memory allowedCustomErrors = new bytes4[](2);
+        allowedCustomErrors[0] = customErrorSelector1;
+        allowedCustomErrors[1] = customErrorSelector2;
+        string memory customErrorContext = "custom error test failed. here is the context";
+
+        // Test with require failure
+        (bool success1, bytes memory requireFailureData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success1, "should fail");
+        // This should pass 1: testing require failure
+        allowErrors(requireFailureData, allowedRequireErrors, allowedCustomErrors, customErrorContext);
+
+        // Test with custom error without message
+        (bool success2, bytes memory customErrorData1) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithoutMessage()"));
+        require(!success2, "should fail");
+        // This should pass 2: testing custom error without message
+        allowErrors(customErrorData1, allowedRequireErrors, allowedCustomErrors, customErrorContext);
+
+        // Test with custom error with message
+        (bool success3, bytes memory customErrorData2) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
+        require(!success3, "should fail");
+        // This should pass 3: testing custom error with message
+        allowErrors(customErrorData2, allowedRequireErrors, allowedCustomErrors, customErrorContext);
+
+        // Test with non-matching error (should fail)
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        bytes memory randomErrorData = abi.encodeWithSelector(bytes4(0x08c379a0), "require failure message");
+        // This should fail
+        allowErrors(randomErrorData, allowedCustomErrors, customErrorContext);
+    }
+
+    // allowErrors() use case 4: allow empty failure such as require(false) or revert()
+    function test_allowErrors_allow_empty_failure() public {
+        string[] memory allowedRequireErrors = new string[](1);
+        allowedRequireErrors[0] = "require failure message 1";
+
+        bytes4[] memory allowedCustomErrors = new bytes4[](1);
+        allowedCustomErrors[0] = bytes4(DummyContract.DummyCustomError2.selector);
+        string memory customErrorContext = "custom error test failed. here is the context";
+
+        // Test with actual require(false);
+        (bool success, bytes memory emptyErrorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithoutMessage()"));
+        require(!success, "should fail");
+        allowErrors(emptyErrorData, allowedRequireErrors, allowedCustomErrors, customErrorContext, true);
+
+        // Test failure case: reusing the same emptyErrorData while allowEmptyError = false
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        allowErrors(emptyErrorData, allowedRequireErrors, allowedCustomErrors, customErrorContext, false); // note that allowEmptyError = false
+
+        // Test with require(false, "message") while allowEmptyError = true
+        (bool success3, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success3, "should fail");
+        // in this case, errorData is not empty. It's 0x08c379a0 + "require failure message 1"
+        // It tests that allowEmptyError = true should not affect other error cases
+        allowErrors(errorData, allowedRequireErrors, allowedCustomErrors, customErrorContext, true);
+    }
+
+    function test_isErrorString() public {
+        // Test with Error(string) selector
+        (bool success, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success, "should fail");
+        assertTrue(_isErrorString(bytes4(errorData)), "should be Error(string) type");
+
+        // Test with custom error
+        (bool success2, bytes memory customErrorData) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithoutMessage()"));
+        require(!success2, "should fail");
+        assertFalse(_isErrorString(bytes4(customErrorData)), "should not be Error(string) type");
+
+        // Test with empty error (require(false))
+        (bool success3, bytes memory emptyErrorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithoutMessage()"));
+        require(!success3, "should fail");
+        assertFalse(_isErrorString(bytes4(emptyErrorData)), "empty error should not be Error(string) type");
+    }
+
+    function test_handleEmptyError() public {
+        // Test when allowEmptyError is true
+        _handleEmptyError(true); // should not revert
+        
+        // Test when allowEmptyError is false
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        _handleEmptyError(false); // should revert
+    }
+
+    function test_allowRequireFailure() public {
+        // Test with matching require failure message
+        (bool success, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success, "should fail");
+        
+        string[] memory allowedRequireErrors = new string[](1);
+        allowedRequireErrors[0] = "require failure message 1";
+        
+        // Test with matching message
+        _allowRequireFailure(errorData, allowedRequireErrors); // should not revert
+        
+        // Test with non-matching message
+        vm.expectRevert(PlatformTest.TestAssertFail.selector);
+        string[] memory nonMatchingErrors = new string[](1);
+        nonMatchingErrors[0] = "different message";
+        _allowRequireFailure(errorData, nonMatchingErrors); // should revert
+    }
+
+    function test_convertToErrorMessage() public {
+        // Test with require failure message
+        (bool success, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
+        require(!success, "should fail");
+        
+        bytes memory strippedData = new bytes(errorData.length - 4);
+        // remove the first 4 bytes which is the selector of the error
+        for (uint i = 0; i < errorData.length - 4; i++) {
+            strippedData[i] = errorData[i + 4];
+        }
+        string memory decodedMessage = _convertToErrorMessage(strippedData);
+        assertEq(decodedMessage, "require failure message 1", "should extract correct error message");
+
+        // Test with custom error message
+        (bool success2, bytes memory customErrorData) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
+        require(!success2, "should fail");
+        bytes memory strippedCustomData = new bytes(customErrorData.length - 4);
+        for (uint i = 0; i < customErrorData.length - 4; i++) {
+            strippedCustomData[i] = customErrorData[i + 4];
+        }
+        string memory customMessage = _convertToErrorMessage(strippedCustomData);
+        assertEq(customMessage, "custom error message", "should extract correct custom error message");
+
+        // Test with empty error data
+        string memory emptyMessage = _convertToErrorMessage(new bytes(0));
+        assertEq(emptyMessage, "unknown error", "should return unknown error for empty data");
     }
 }

--- a/test/Assert.t.sol
+++ b/test/Assert.t.sol
@@ -371,34 +371,6 @@ contract TestAsserts is Test, HelperAssert {
         _allowRequireFailure(errorData, nonMatchingErrors); // should revert
     }
 
-    function test_convertToErrorMessage() public {
-        // Test with require failure message
-        (bool success, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
-        require(!success, "should fail");
-        
-        bytes memory strippedData = new bytes(errorData.length - 4);
-        // remove the first 4 bytes which is the selector of the error
-        for (uint i = 0; i < errorData.length - 4; i++) {
-            strippedData[i] = errorData[i + 4];
-        }
-        string memory decodedMessage = _convertToErrorMessage(strippedData);
-        assertEq(decodedMessage, "require failure message 1", "should extract correct error message");
-
-        // Test with custom error message
-        (bool success2, bytes memory customErrorData) = address(dummy).call(abi.encodeWithSignature("revertWithCustomErrorWithMessage()"));
-        require(!success2, "should fail");
-        bytes memory strippedCustomData = new bytes(customErrorData.length - 4);
-        for (uint i = 0; i < customErrorData.length - 4; i++) {
-            strippedCustomData[i] = customErrorData[i + 4];
-        }
-        string memory customMessage = _convertToErrorMessage(strippedCustomData);
-        assertEq(customMessage, "custom error message", "should extract correct custom error message");
-
-        // Test with empty error data
-        string memory emptyMessage = _convertToErrorMessage(new bytes(0));
-        assertEq(emptyMessage, "unknown error", "should return unknown error for empty data");
-    }
-
     /**
      * "errAllow" test
      */

--- a/test/Assert.t.sol
+++ b/test/Assert.t.sol
@@ -371,7 +371,7 @@ contract TestAsserts is Test, HelperAssert {
         assertFalse(_isErrorString(bytes4(emptyErrorData)), "empty error should not be Error(string) type");
     }
 
-    function test_allowRequireFailure() public {
+    function test_errAllow_require_only_failure() public {
         // Test with matching require failure message
         (bool success, bytes memory errorData) = address(dummy).call(abi.encodeWithSignature("requireFailWithMessage()"));
         require(!success, "should fail");
@@ -380,12 +380,12 @@ contract TestAsserts is Test, HelperAssert {
         allowedRequireErrors[0] = "require failure message 1";
         
         // Test with matching message
-        _allowRequireFailure(errorData, allowedRequireErrors, "BAL-01"); // should not revert
+        errAllow(errorData, allowedRequireErrors, "BAL-01"); // should not revert
         
         // Test with non-matching message
         vm.expectRevert(PlatformTest.TestAssertFail.selector);
         string[] memory nonMatchingErrors = new string[](1);
         nonMatchingErrors[0] = "different message";
-        _allowRequireFailure(errorData, nonMatchingErrors, "BAL-02"); // should revert
+        errAllow(errorData, nonMatchingErrors, "BAL-02"); // should revert
     }
 }

--- a/test/util/DummyContract.sol
+++ b/test/util/DummyContract.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * A dummy contract for testing purposes
+ */
+contract DummyContract {
+    error DummyCustomError1();
+    error DummyCustomError2(string message);
+
+    function requireFailWithoutMessage() public pure {
+        require(false);
+    }
+
+    function requireFailWithMessage() public pure {
+        require(false, "require failure message 1");
+    }
+
+    function revertWithCustomErrorWithoutMessage() public pure {
+        revert DummyCustomError1();
+    }
+
+    function revertWithCustomErrorWithMessage() public pure {
+        revert DummyCustomError2("custom error message");
+    }
+} 

--- a/test/util/ErrAllowTestHelper.sol
+++ b/test/util/ErrAllowTestHelper.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {DummyContract} from "./DummyContract.sol";
+
+contract ErrAllowTestHelper {
+    function setup_errAllow_require_error() internal pure returns (string[] memory) {
+        // set require failure related
+        string[] memory allowedRequireErrors = new string[](2);
+        allowedRequireErrors[0] = "require failure message 1";
+        allowedRequireErrors[1] = "require failure message 2";
+
+        return allowedRequireErrors;
+    }
+
+    function setup_errAllow_custom_error() internal pure returns (bytes4[] memory) {
+        // set custom error related
+        bytes4 customErrorSelector1 = bytes4(DummyContract.DummyCustomError1.selector);
+        bytes4 customErrorSelector2 = bytes4(DummyContract.DummyCustomError2.selector);
+        bytes4[] memory allowedCustomErrors = new bytes4[](2);
+        allowedCustomErrors[0] = customErrorSelector1;
+        allowedCustomErrors[1] = customErrorSelector2;
+
+        return allowedCustomErrors;
+    }
+}


### PR DESCRIPTION
## Implement `allowErrors` function 
1. It does the same thing as `errAllow` which allow custom error (ex: `revert SomeError();`)
2. It also allows `require` failure with message (ex: `require(false, "some fail message");`)
3. It allows `require` failure WITHOUT message (ex: `require(false);`. _Note that this cant be arguable. I will talk about this in the below._

## Implementation
It is a sort of extension version of `errAllow`. While `errAllow` takes care of custom error, `allowErrors` takes require failure as well. And you can select whether only accept require failure or custom error or both.
1. `allowErrors(errorData, allowedRequireErrorMessages); // require failure`
2. `allowErrors(errorData, allowedCustomErrors, errorContext); // custom error`
3. `allowErrors(errorData, allowedRequireErrorMessages, allowedCustomErrors, errorContext); // both`
4. `allowErrors(errorData, allowedRequireErrorMessages, allowedCustomErrors, errorContext, true); // both + require failure without message`.

## Test
1. You will see how to use this function for test (`Assert.t.sol`)
2. I added `DummyContract` to simulate test rather than create a fake failure data

## Things to discuss
1. It's about `allowEmptyError` param. 
When `require` fails without message (e.g.: `require(false);`), the returned bytes data is empty. I added code that handle this (only when `allowEmptyError` is true). So user can skip or allow this kind of error.
However, I am skeptical that `require(false);` exists on production level smart contract code.
On top of that, non-existing address calling also returns an empty data (ex: `address(0xdead).call(...);`). 
So this can cause some confusion. I'd like to know your opinions.
1. I split functions that helps `allowErrors` such as `_isErrorString`, `_handleEmptyError`, `_allowRequireFailure` and `_convertToErrorMessage` for readability, scaleability. They are not supposed to be used by user but I left them as `internal` in order to test on `Assert.t.sol`. 
I will think about how to prevent them and keep the code being well separated. If you guys know any suggestion, please let me know.